### PR TITLE
sql servers allows 63 characters

### DIFF
--- a/azurerm/modules/azurerm-sql/main.tf
+++ b/azurerm/modules/azurerm-sql/main.tf
@@ -8,7 +8,7 @@ resource "random_password" "password" {
 
 # SQL Server instance
 resource "azurerm_mssql_server" "example" {
-  name                          = substr(replace("${var.resource_namer}-sql", "-", ""), 0, 24)
+  name                          = substr(replace("${var.resource_namer}-sql", "-", ""), 0, 63)
   resource_group_name           = var.resource_group_name
   location                      = var.resource_group_location
   version                       = var.sql_version


### PR DESCRIPTION
#### 📲 What

sql servers allows 63 characters

#### 🤔 Why

this is inconsistent with stacks data where we allow 63 characters and then it gets stripped to 24 which means it loses the environment value and then we get conflicts with other resources.

#### 🛠 How

updated from 24 to 63
