### PR TITLE
update azure build agent version

### DIFF
--- a/azurerm/modules/azurerm-vmss/main.tf
+++ b/azurerm/modules/azurerm-vmss/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     publisher = "Microsoft.VisualStudio.Services"
     settings = jsonencode(
       {
-        agentDownloadUrl        = "https://vstsagentpackage.azureedge.net/agent/3.220.2/vsts-agent-linux-x64-3.220.2.tar.gz"
+        agentDownloadUrl        = "https://vstsagentpackage.azureedge.net/agent/3.225.0/vsts-agent-linux-x64-3.225.0.tar.gz"
         agentFolder             = "/agent"
         enableScriptDownloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/ElasticPools/Linux/15/enableagent.sh"
         isPipelinesAgent        = true


### PR DESCRIPTION
#### 📲 What

Updated agent version to 3.225.0. 

#### 🤔 Why

When the scaleset automatically scales it also upgrades that extension which means when we run the terraform again it reverts it back.

This is just a quick fix because we need to understand why its updating it when auto_upgrade_minor_version is false

#### 👀 Evidence

Azure updating the agent.
![image](https://github.com/Ensono/stacks-terraform/assets/47520690/ebe21980-b782-44f8-a236-ab6522b0f618)

Also this module should really be called azurerm-build-agent-vmss because its creating a build agent and isn't a generic module to create vmss but this is a separate issue. 