### PR TITLE
Feat/18 - added release process for the terraform modules repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ override.tf.json
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Taskctl Build
+envfile
+.env
+/tmp
+tfplan

--- a/azurerm/modules/azurerm-adls/main.tf
+++ b/azurerm/modules/azurerm-adls/main.tf
@@ -101,7 +101,7 @@ resource "null_resource" "sleep" {
       sleep 60
     EOT
   }
-  depends_on = [azurerm_storage_account.storage_account_default,azurerm_private_endpoint.pe_blob,azurerm_private_endpoint.pe_dfs]
+  depends_on = [azurerm_storage_account.storage_account_default, azurerm_private_endpoint.pe_blob, azurerm_private_endpoint.pe_dfs]
 }
 
 resource "azurerm_storage_container" "storage_container_blob" {

--- a/azurerm/modules/azurerm-kv/main.tf
+++ b/azurerm/modules/azurerm-kv/main.tf
@@ -72,7 +72,7 @@ resource "null_resource" "sleep" {
       sleep 100
     EOT
   }
-  depends_on = [azurerm_private_endpoint.pe , azurerm_key_vault_access_policy.contributors_access_policy]
+  depends_on = [azurerm_private_endpoint.pe, azurerm_key_vault_access_policy.contributors_access_policy]
 }
 
 resource "azurerm_key_vault_access_policy" "contributors_access_policy" {

--- a/build/azdo/agent-config-vars.yml
+++ b/build/azdo/agent-config-vars.yml
@@ -1,0 +1,7 @@
+variables:
+
+  # Agent configuration
+  - name: pool_vm_image
+    value: ubuntu-22.04
+  - name: TaskctlVersion
+    value: 1.5.0

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -64,5 +64,12 @@ stages:
             targetType: inline
             script: |
               taskctl release
-            env:
-              test: "test"
+
+        - task: Bash@3
+          displayName: Create Terraform variables file
+          inputs:
+            targetType: inline
+            script: |
+              taskctl release
+          env:
+            TF_FILE_LOCATION: "deploy/aws/stacks-eks"

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -68,3 +68,4 @@ stages:
             STAGE: "release"
             PUBLISH_RELEASE: "true"
             VERSION_NUMBER: $(BUILD_BUILDNUMBER)
+            PRERELEASE: ${{ parameters.force_release }}

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -64,3 +64,5 @@ stages:
             targetType: inline
             script: |
               taskctl release
+            env:
+              test: "test"

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -65,6 +65,6 @@ stages:
             script: |
               taskctl release
             env:
-              STAGE: release
-              PUBLISH_RELEASE: "true"
-              VERSION_NUMBER: $(BUILD_BUILDNUMBER)
+              - STAGE: release
+              - PUBLISH_RELEASE: "true"
+              - VERSION_NUMBER: $(BUILD_BUILDNUMBER)

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -1,0 +1,70 @@
+
+# Set the build name which will define the Build Number
+name: 2.0$(Rev:.r)
+
+pr:
+  - main
+
+trigger:
+  branches:
+    include:
+      - 'main'
+
+# Set the agent pool that stages should be run in
+pool:
+  vmImage: $(pool_vm_image)
+
+# Configure parameters for running the build
+parameters:
+  - name: force_release
+    displayName: Force release regardless of branch
+    type: boolean
+    default: false
+
+variables:
+  - template: azuredevops-vars.yml
+  - template: agent-config-vars.yml
+
+# Configure the stages
+stages:
+
+  - stage: Build
+
+    jobs:
+
+    - job: Format
+
+      steps:
+
+        - template: templates/setup.yml
+            parameters:
+              TaskctlVersion: ${{ variables.TaskctlVersion }}
+
+        - task: Bash@3
+          displayName: Check Terraform Formatting
+          inputs:
+            targetType: inline
+            script: |
+              taskctl format
+
+  - stage: Release
+    condition: and(succeeded(), or(${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}, ${{ parameters.force_release }}))
+    jobs:
+
+    - job: Publish
+      steps:
+        - template: templates/setup.yml
+            parameters:
+              TaskctlVersion: ${{ variables.TaskctlVersion }}
+
+        # Publish to GitHub and Build Dashboard
+        - task: Bash@3
+          displayName: Publish Release
+          inputs:
+            targetType: inline
+            script: |
+              taskctl release
+            env:
+              STAGE: release
+              PUBLISH_RELEASE: "true"
+              VERSION_NUMBER: $(BUILD_BUILDNUMBER)

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -64,7 +64,3 @@ stages:
             targetType: inline
             script: |
               taskctl release
-            env:
-              STAGE: release
-              PUBLISH_RELEASE: "true"
-              VERSION_NUMBER: $(BUILD_BUILDNUMBER)

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -54,8 +54,8 @@ stages:
     - job: Publish
       steps:
         - template: templates/setup.yml
-            parameters:
-              TaskctlVersion: ${{ variables.TaskctlVersion }}
+          parameters:
+            TaskctlVersion: ${{ variables.TaskctlVersion }}
 
         # Publish to GitHub and Build Dashboard
         - task: Bash@3

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -57,19 +57,14 @@ stages:
           parameters:
             TaskctlVersion: ${{ variables.TaskctlVersion }}
 
-        # Publish to GitHub and Build Dashboard
+        # Publish to GitHub
         - task: Bash@3
           displayName: Publish Release
           inputs:
             targetType: inline
             script: |
               taskctl release
-
-        - task: Bash@3
-          displayName: Create Terraform variables file
-          inputs:
-            targetType: inline
-            script: |
-              taskctl release
           env:
-            TF_FILE_LOCATION: "deploy/aws/stacks-eks"
+            STAGE: "release"
+            PUBLISH_RELEASE: "true"
+            VERSION_NUMBER: $(BUILD_BUILDNUMBER)

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -65,6 +65,6 @@ stages:
             script: |
               taskctl release
             env:
-              - STAGE: release
-              - PUBLISH_RELEASE: "true"
-              - VERSION_NUMBER: $(BUILD_BUILDNUMBER)
+              STAGE: release
+              PUBLISH_RELEASE: "true"
+              VERSION_NUMBER: $(BUILD_BUILDNUMBER)

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -37,8 +37,8 @@ stages:
       steps:
 
         - template: templates/setup.yml
-            parameters:
-              TaskctlVersion: ${{ variables.TaskctlVersion }}
+          parameters:
+            TaskctlVersion: ${{ variables.TaskctlVersion }}
 
         - task: Bash@3
           displayName: Check Terraform Formatting

--- a/build/azdo/azuredevops-vars.yml
+++ b/build/azdo/azuredevops-vars.yml
@@ -1,0 +1,15 @@
+# GitHub Release
+  - name: VERSION_NUMBER
+    value: $(Build.BuildNumber)
+  - name: COMMIT_ID
+    value: $(Build.SourceVersion)
+  - name: OWNER
+    value: ensono
+  - name: REPOSITORY
+    value: stacks-terraform
+  - name: ARTIFACTS_DIR
+    value: artifacts/
+  - group: amido-stacks-github-credentials
+    # Group should contain: 
+      # API_KEY
+

--- a/build/azdo/azuredevops-vars.yml
+++ b/build/azdo/azuredevops-vars.yml
@@ -1,4 +1,4 @@
-# GitHub Release
+variables:
   - name: VERSION_NUMBER
     value: $(Build.BuildNumber)
   - name: COMMIT_ID

--- a/build/azdo/templates/setup.yml
+++ b/build/azdo/templates/setup.yml
@@ -1,0 +1,15 @@
+parameters:
+  TaskctlVersion: 1.5.0
+
+steps:
+  # Checkout self repo
+  - checkout: self
+
+  # Install Taskfile so that the tests can be run
+  - task: Bash@3
+    displayName: "Install: Taskctl"
+    inputs:
+      targetType: inline
+      script: |
+        wget https://github.com/russellseymour/taskctl/releases/download/v${{ parameters.TaskctlVersion }}/taskctl_${{ parameters.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
+        tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl

--- a/build/config/stage_envvars.yml
+++ b/build/config/stage_envvars.yml
@@ -1,0 +1,16 @@
+default:
+  variables:
+
+stages:
+
+  - name: release
+    variables:
+      - name: OWNER
+      - name: API_KEY
+      - name: PUBLISH_RELEASE
+      - name: COMMIT_ID
+      - name: VERSION_NUMBER
+      - name: ARTIFACTS_DIR
+      - name: REPOSITORY
+
+  

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -1,0 +1,24 @@
+contexts:
+  powershell:
+    executable:
+      bin: docker
+      args:
+        - run
+        - --rm
+        - -v
+        - ${PWD}:/app
+        - -v
+        - /var/run/docker.sock:/var/run/docker.sock
+        - -e
+        - PSModulePath=/modules
+        - -w
+        - /app
+        - --env-file
+        - envfile
+        - amidostacks/runner-pwsh:0.4.20-stable
+        - pwsh
+        - -NoProfile
+        - -NonInteractive
+        - -Command
+    quote: "'"
+    before: env | grep -v PATH | grep -v SOURCEVERSIONMESSAGE | grep -v HOME > envfile

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -1,0 +1,19 @@
+tasks:
+
+  terraform:format:
+    context: powershell
+    description: Check Terraform Formatting
+    command:
+      - Invoke-Terraform -Format
+
+  setup:environment:
+    context: powershell
+    description: Ensure that the environment is configured correctly
+    command:
+      - Confirm-Environment -Path /app/build/config/stage_envvars.yml
+
+  publish:github:
+    context: powershell
+    description: Publish Release to GitHub
+    command:
+      - Publish-GitHubRelease -generateReleaseNotes $true

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -1,0 +1,17 @@
+import:
+- ./build/taskctl/contexts.yaml
+- ./build/taskctl/tasks.yaml
+
+pipelines:
+
+  format:
+    - task: terraform:format
+
+  release:
+    - task: terraform:format
+    - task: setup:environment
+      depends_on:
+        - terraform:format
+    - task: publish:github
+      depends_on:
+        - setup:environment


### PR DESCRIPTION
#### 📲 What

Created a pipeline that runs when a PR is opened and when merged into main.
For now the pipeline is quite basic and only runs a terraform fmt check. 
Once merged to main, it creates a release with release notes

Added a force_release option so we can create a pre-release from feature branches. 

Also fixed formatting errors

#### 🤔 Why

Now we don't need to manually create a release. We can reference specific tags when used in other projects

#### 🛠 How

Using the independent runner Publish-GitHubRelease to create the release package

#### 👀 Evidence
Created from feature branch:
![image](https://github.com/Ensono/stacks-terraform/assets/47520690/e961a7a1-0261-4795-a4d8-70f1912c40b8)
