### PR TITLE
Removed provider from module to prevent legacy detection

### DIFF
--- a/azurerm/modules/azurerm-app-gateway/provider.tf
+++ b/azurerm/modules/azurerm-app-gateway/provider.tf
@@ -1,4 +1,0 @@
-provider "acme" {
-  # USe Staging endpoint
-  server_url = "https://acme-v02.api.letsencrypt.org/directory"
-}


### PR DESCRIPTION
#### 📲 What

Removed the `provider.tf` from the module dicrectory.

#### 🤔 Why

When this is in place the module is seen as lagacy and later versions of Terraform will not download the module.

#### 🛠 How

Removed the `provider.tf` file from source control.

#### 👀 Evidence

Files are downloaded correctly

![image](https://github.com/Ensono/stacks-terraform/assets/791658/1e1adcf3-00be-4544-a6b3-5aa712cbf78d)


#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
