### PR TITLE
fix: Fixes App Gateway and AKS Additional Nodes

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -95,6 +95,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   min_count           = each.value.min_nodes
   max_count           = each.value.max_nodes
   node_count          = each.value.min_nodes
+  vnet_subnet_id      = azurerm_subnet.default.0.id
 }
 
 # perform lookup on existing ACR for stages where we don't want to create an ACR

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -125,11 +125,8 @@ variable "ssl_policy" {
   type        = object({ policy_type = string, policy_name = string, min_protocol_version = string, disabled_protocols = list(string), cipher_suites = list(string) })
   description = "SSL policy definition, defaults to latest Predefined settings with min protocol of TLSv1.2"
   default = {
-    "policy_type"          = "Predefined",
-    "policy_name"          = "AppGwSslPolicy20170401S",
-    "min_protocol_version" = "TLSv1_2",
-    "disabled_protocols"   = null,
-    "cipher_suites"        = null
+    "policy_type" = "Predefined",
+    "policy_name" = "AppGwSslPolicy20220101",
   }
 }
 


### PR DESCRIPTION
 * Ups App Gateway to 2022 security standards
 * Removes defunct `min_protocol_versions` as we use `Preset` which defines this
 * Fixes Worker Nodes constantly recreating by adding VNET Subnet to it explicitly