### PR TITLE
fix: Bumps min TF version and uses optional

### DIFF
--- a/azurerm/modules/azurerm-aks/constraints.tf
+++ b/azurerm/modules/azurerm-aks/constraints.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.5.1"
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -122,8 +122,21 @@ variable "aks_resource_group" {
 ##########################
 
 variable "ssl_policy" {
-  type        = object({ policy_type = string, policy_name = string, min_protocol_version = string, disabled_protocols = list(string), cipher_suites = list(string) })
+  # NOTE: If you use `policy_type` as `Predefined`, the three variables,
+  # `min_protocol_version`, `disabled_protocols`, and `cipher_suites`
+  # will be ignored and TF will keep trying to apply them each run...
+  type = object(
+    {
+      policy_type          = string,
+      policy_name          = string,
+      min_protocol_version = optional(string, null),
+      disabled_protocols   = optional(list(string), null),
+      cipher_suites        = optional(list(string), null),
+    }
+  )
+
   description = "SSL policy definition, defaults to latest Predefined settings with min protocol of TLSv1.2"
+
   default = {
     "policy_type" = "Predefined",
     "policy_name" = "AppGwSslPolicy20220101",


### PR DESCRIPTION
 * Bumps the minimum TF version to 1.5.1, which is in our images
 * Uses Optional around App Gateway SSL policy and adds a note about defunct params when using `Predefined`