### PR TITLE
Adding node instance tenancy variable

### DIFF
--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -79,6 +79,9 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     disk_size = 50
+    placement = {
+      tenancy = var.eks_node_tenancy
+    }
   }
 
   eks_managed_node_groups = local.eks_managed_node_groups

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -83,3 +83,15 @@ variable "eks_node_type" {
     error_message = "Value must be one of ON_DEMAND, or SPOT."
   }
 }
+
+variable "eks_node_tenancy" {
+  type        = string
+  description = "The tenancy of the node instance to use for EKS"
+
+  default = "default"
+
+  validation {
+    condition     = contains(["default", "dedicated", "host"], var.eks_node_tenancy)
+    error_message = "Value must be one of 'default', 'dedicated', or 'host'."
+  }
+}


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Adding EKS node instance tenancy as a variable.


#### 🤔 Why

In Pay.UK we need to use dediacted instances for the EKS nodes instead of the default shared instances. So making tenancy as a variable and setting the default value to 'default' which corresponds to shared instances.

