### PR TITLE
Feature/payuk bottlerocket

### DIFF
--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -16,18 +16,17 @@ locals {
   mode = "always"
   [settings.kernel]
   lockdown = "integrity"
-  sysctl = <<-EOF
-    "net.ipv4.conf.all.send_redirects = 0"
-    "net.ipv4.conf.default.send_redirects = 0"
-    "net.ipv4.conf.all.accept_redirects = 0"
-    "net.ipv4.conf.default.accept_redirects = 0"
-    "net.ipv6.conf.all.accept_redirects = 0"
-    "net.ipv6.conf.default.accept_redirects = 0"
-    "net.ipv4.conf.all.secure_redirects = 0"
-    "net.ipv4.conf.default.secure_redirects = 0"
-    "net.ipv4.conf.all.log_martians = 1"
-    "net.ipv4.conf.default.log_martians = 1"
-  EOF 
+  [settings.kernel.sysctl]
+  "net.ipv4.conf.all.send_redirects" = "0"
+  "net.ipv4.conf.default.send_redirects" = "0"
+  "net.ipv4.conf.all.accept_redirects" = "0"
+  "net.ipv4.conf.default.accept_redirect" = "0"
+  "net.ipv6.conf.all.accept_redirects" = "0"
+  "net.ipv6.conf.default.accept_redirects" = "0"
+  "net.ipv4.conf.all.secure_redirects" = "0"
+  "net.ipv4.conf.default.secure_redirects" = "0"
+  "net.ipv4.conf.all.log_martians" = "1"
+  "net.ipv4.conf.default.log_martians" = "1"
   [settings.kernel.modules.udf]
   allowed = "false"
   [settings.kernel.modules.sctp]

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -89,6 +89,3 @@ locals {
       "Name" = local.logging_bucket_kms_key_name
     })
   )
-}
-
-variable

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -10,7 +10,7 @@ locals {
   "node.kubernetes.io/lifecycle" = "spot"
   EOT
 
-  eks_on_demand_bootstrap_extra_args = <<-EOT
+  eks_on_demand_bootstrap_extra_args = var.enable_cis_bootstrap ? <<-EOT
   [settings.bootstrap-containers.cis-bootstrap]
   source = "${data.aws_caller_identity.this.account_id}.dkr.ecr.${var.region}.amazonaws.com/bottlerocket-cis-spike:latest"
   mode = "always"

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -34,7 +34,7 @@ locals {
   "net.ipv4.conf.default.log_martians" = "1"
   %{ endif }
   EOT
-}
+
   eks_bottlerocket_base_node_config = {
     ami_type        = "BOTTLEROCKET_x86_64"
     platform        = "bottlerocket"
@@ -89,3 +89,4 @@ locals {
       "Name" = local.logging_bucket_kms_key_name
     })
   )
+}

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -12,7 +12,7 @@ locals {
 
   eks_on_demand_bootstrap_extra_args = <<-EOT
   [settings.bootstrap-containers.cis-boostrap]
-  source = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$BOOTSTRAP_ECR_REPO:latest"
+  source = "${data.aws_caller_identity.this.account_id}.dkr.ecr.${var.region}.amazonaws.com/bottlerocket-cis-spike:latest"
   mode = "always"
   [settings.kernel]
   lockdown = "integrity"

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -11,8 +11,27 @@ locals {
   EOT
 
   eks_on_demand_bootstrap_extra_args = <<-EOT
+  [settings.bootstrap-containers.cis-boostrap]
+  source = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$BOOTSTRAP_ECR_REPO:latest"
+  mode = "always"
   [settings.kernel]
   lockdown = "integrity"
+  sysctl = <<-EOF
+    "net.ipv4.conf.all.send_redirects = 0"
+    "net.ipv4.conf.default.send_redirects = 0"
+    "net.ipv4.conf.all.accept_redirects = 0"
+    "net.ipv4.conf.default.accept_redirects = 0"
+    "net.ipv6.conf.all.accept_redirects = 0"
+    "net.ipv6.conf.default.accept_redirects = 0"
+    "net.ipv4.conf.all.secure_redirects = 0"
+    "net.ipv4.conf.default.secure_redirects = 0"
+    "net.ipv4.conf.all.log_martians = 1"
+    "net.ipv4.conf.default.log_martians = 1"
+  EOF 
+  [settings.kernel.udf]
+  allowed = "false"
+  [settings.kernel.sctp]
+  allowed = "false"
   EOT
 
   eks_bottlerocket_base_node_config = {

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -16,17 +16,6 @@ locals {
   mode = "always"
   [settings.kernel]
   lockdown = "integrity"
-  [settings.kernel.sysctl]
-  "net.ipv4.conf.all.send_redirects" = "0"
-  "net.ipv4.conf.default.send_redirects" = "0"
-  "net.ipv4.conf.all.accept_redirects" = "0"
-  "net.ipv4.conf.default.accept_redirect" = "0"
-  "net.ipv6.conf.all.accept_redirects" = "0"
-  "net.ipv6.conf.default.accept_redirects" = "0"
-  "net.ipv4.conf.all.secure_redirects" = "0"
-  "net.ipv4.conf.default.secure_redirects" = "0"
-  "net.ipv4.conf.all.log_martians" = "1"
-  "net.ipv4.conf.default.log_martians" = "1"
   [settings.kernel.modules.udf]
   allowed = "false"
   [settings.kernel.modules.sctp]

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -12,7 +12,7 @@ locals {
   %{ endif }
   %{ if var.enable_cis_bootstrap == true }
   [settings.bootstrap-containers.cis-bootstrap]
-  source = "${var.cis_boostrap_image}"
+  source = "${var.cis_bootstrap_image}"
   mode = "always"
 
   [settings.kernel.modules.udf]

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -6,11 +6,11 @@ locals {
   eks_bootstrap_extra_args = <<-EOT
   [settings.kernel]
   lockdown = "integrity"
-  %{ if var.eks_node_type == "SPOT" }
+  %{if var.eks_node_type == "SPOT"}
   [settings.kubernetes.node-labels]
   "node.kubernetes.io/lifecycle" = "spot"
-  %{ endif }
-  %{ if var.enable_cis_bootstrap == true }
+  %{endif}
+  %{if var.enable_cis_bootstrap == true}
   [settings.bootstrap-containers.cis-bootstrap]
   source = "${var.cis_bootstrap_image}"
   mode = "always"
@@ -32,7 +32,7 @@ locals {
   "net.ipv4.conf.default.secure_redirects" = "0"
   "net.ipv4.conf.all.log_martians" = "1"
   "net.ipv4.conf.default.log_martians" = "1"
-  %{ endif }
+  %{endif}
   EOT
 
   eks_bottlerocket_base_node_config = {

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -11,15 +11,30 @@ locals {
   EOT
 
   eks_on_demand_bootstrap_extra_args = <<-EOT
-  [settings.bootstrap-containers.cis-boostrap]
+  [settings.bootstrap-containers.cis-bootstrap]
   source = "${data.aws_caller_identity.this.account_id}.dkr.ecr.${var.region}.amazonaws.com/bottlerocket-cis-spike:latest"
   mode = "always"
+
   [settings.kernel]
   lockdown = "integrity"
+
   [settings.kernel.modules.udf]
-  allowed = "false"
+  allowed = false
+
   [settings.kernel.modules.sctp]
-  allowed = "false"
+  allowed = false
+
+  [settings.kernel.sysctl]
+  "net.ipv4.conf.all.send_redirects" = "0"
+  "net.ipv4.conf.default.send_redirects" = "0"
+  "net.ipv4.conf.all.accept_redirects" = "0"
+  "net.ipv4.conf.default.accept_redirects" = "0"
+  "net.ipv6.conf.all.accept_redirects" = "0"
+  "net.ipv6.conf.default.accept_redirects" = "0"
+  "net.ipv4.conf.all.secure_redirects" = "0"
+  "net.ipv4.conf.default.secure_redirects" = "0"
+  "net.ipv4.conf.all.log_martians" = "1"
+  "net.ipv4.conf.default.log_martians" = "1"
   EOT
 
   eks_bottlerocket_base_node_config = {

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -28,9 +28,9 @@ locals {
     "net.ipv4.conf.all.log_martians = 1"
     "net.ipv4.conf.default.log_martians = 1"
   EOF 
-  [settings.kernel.udf]
+  [settings.kernel.modules.udf]
   allowed = "false"
-  [settings.kernel.sctp]
+  [settings.kernel.modules.sctp]
   allowed = "false"
   EOT
 

--- a/aws/modules/infrastructure_modules/eks/validation.tf
+++ b/aws/modules/infrastructure_modules/eks/validation.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "cis_bootstrap_validation" {
+  lifecycle {
+    precondition {
+      condition     = (var.enable_cis_bootstrap == true && var.cis_bootstrap_image != "") || var.enable_cis_bootstrap == false
+      error_message = "cis_bootstrap_image must be set if enable_cis_bootstrap is true"
+    }
+  }
+}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -107,3 +107,12 @@ variable "cis_bootstrap_image" {
   type = string
   default = null
 }
+
+resource "null_resource" "cis_bootstrap_validation" {
+  lifecycle {
+    precondition {
+      condition     = (var.enable_cis_bootstrap == true && var.cis_bootstrap_image != "") || var.enable_cis_bootstrap == false
+      error_message = "cis_bootstrap_image must be set if enable_cis_bootstrap is true"
+    }
+  }
+}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -84,6 +84,7 @@ variable "eks_node_type" {
   }
 }
 
+<<<<<<< HEAD
 variable "eks_node_tenancy" {
   type        = string
   description = "The tenancy of the node instance to use for EKS"
@@ -95,3 +96,10 @@ variable "eks_node_tenancy" {
     error_message = "Value must be one of 'default', 'dedicated', or 'host'."
   }
 }
+=======
+variable "variable "enable_cis_bootstrap" {
+  description = "Set to true to enable the CIS Boostrap, false to disable."
+  type        = bool
+  default     = false
+}
+>>>>>>> a7c156e (Add variable to enable and disbale)

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -95,8 +95,15 @@ variable "eks_node_tenancy" {
     error_message = "Value must be one of 'default', 'dedicated', or 'host'."
   }
 }
-variable "variable "enable_cis_bootstrap" {
+variable "enable_cis_bootstrap" {
   description = "Set to true to enable the CIS Boostrap, false to disable."
   type        = bool
   default     = false
+}
+
+
+variable "cis_bootstrap_image" {
+  description = "CIS Bootstrap image, required if enable_cis_bootstrap is set to true"
+  type = string
+  default = null
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -107,12 +107,3 @@ variable "cis_bootstrap_image" {
   type        = string
   default     = ""
 }
-
-resource "null_resource" "cis_bootstrap_validation" {
-  lifecycle {
-    precondition {
-      condition     = (var.enable_cis_bootstrap == true && var.cis_bootstrap_image != "") || var.enable_cis_bootstrap == false
-      error_message = "cis_bootstrap_image must be set if enable_cis_bootstrap is true"
-    }
-  }
-}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -104,8 +104,8 @@ variable "enable_cis_bootstrap" {
 
 variable "cis_bootstrap_image" {
   description = "CIS Bootstrap image, required if enable_cis_bootstrap is set to true"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 resource "null_resource" "cis_bootstrap_validation" {

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -105,7 +105,7 @@ variable "enable_cis_bootstrap" {
 variable "cis_bootstrap_image" {
   description = "CIS Bootstrap image, required if enable_cis_bootstrap is set to true"
   type = string
-  default = null
+  default = ""
 }
 
 resource "null_resource" "cis_bootstrap_validation" {

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -84,7 +84,6 @@ variable "eks_node_type" {
   }
 }
 
-<<<<<<< HEAD
 variable "eks_node_tenancy" {
   type        = string
   description = "The tenancy of the node instance to use for EKS"
@@ -96,10 +95,8 @@ variable "eks_node_tenancy" {
     error_message = "Value must be one of 'default', 'dedicated', or 'host'."
   }
 }
-=======
 variable "variable "enable_cis_bootstrap" {
   description = "Set to true to enable the CIS Boostrap, false to disable."
   type        = bool
   default     = false
 }
->>>>>>> a7c156e (Add variable to enable and disbale)


### PR DESCRIPTION
#### 📲 What

Changes in the EKS cluster to allow the option of deploying a cluster that follows the CIS benchmark. 

#### Azure DevOps ticket
https://dev.azure.com/PayUK/Pay.UK%20API%20Platform/_sprints/taskboard/Squad%202%20-%20Platform%20and%20API%20Build/Pay.UK%20API%20Platform/Sprint%205?workitem=744

#### 🤔 Why

Pay UK require that EKS cluster to follow the CIS benchmark level 2. This change allows eks cluster to be deployed with the CIS bootstrap enabled.

#### 🛠 How

https://aws.amazon.com/blogs/containers/validating-amazon-eks-optimized-bottlerocket-ami-against-the-cis-benchmark/

#### 👀 Evidence

https://aws.amazon.com/blogs/containers/validating-amazon-eks-optimized-bottlerocket-ami-against-the-cis-benchmark/

#### 🕵️ How to test

https://aws.amazon.com/blogs/containers/validating-amazon-eks-optimized-bottlerocket-ami-against-the-cis-benchmark/

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
