### PR TITLE
feat: expose cluster ARN for kube-bench config in customer project

### DIFF
--- a/aws/modules/infrastructure_modules/eks/outputs.tf
+++ b/aws/modules/infrastructure_modules/eks/outputs.tf
@@ -3,6 +3,11 @@ output "cluster_id" {
   value       = module.eks.cluster_id
 }
 
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.eks.cluster_arn
+}
+
 output "cluster_endpoint" {
   description = "Endpoint for EKS control plane."
   value       = module.eks.cluster_endpoint


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Expose EKS Cluster ARN 

#### 🤔 Why

This variable is required in configuration of various other tools.

#### 🛠 How

Exposed via terraform output.

#### 👀 Evidence


![Screenshot 2024-05-31 at 10 12 52](https://github.com/Ensono/stacks-terraform/assets/65091252/079087b5-c1fd-40bf-8b90-16e3f8510563)


#### 🕵️ How to test

execute terraform plan and apply

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
