### PR TITLE
feat: amend kms policy for encryption

### DIFF
--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 

--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -3,6 +3,12 @@ data "aws_caller_identity" "this" {}
 
 data "aws_availability_zones" "available" {}
 
+locals {
+  
+  trusted_key_identities = var.trusted_role_arn == "" ? ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"] : ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"]
+}
+  
+
 ## EKS
 data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
   statement {
@@ -11,10 +17,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
 
     principals {
       type = "AWS"
-
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -44,9 +47,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     principals {
       type = "AWS"
 
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -67,9 +68,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     principals {
       type = "AWS"
 
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -130,7 +130,13 @@ variable "managed_node_groups_iam_role_additional_policies" {
 }
 
 variable "trusted_role_arn" {
-  description = "Additional IAM role passed to KMS Policy"
+  description = "IAM role passed to KMS Policy"
+  type        = string
+  default     = ""
+}
+
+variable "trusted_key_identities" {
+  description = "IAM Identities that need to be trusted by the KMS Service"
   type        = string
   default     = ""
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -134,9 +134,3 @@ variable "trusted_role_arn" {
   type        = string
   default     = ""
 }
-
-variable "trusted_key_identities" {
-  description = "IAM Identities that need to be trusted by the KMS Service"
-  type        = string
-  default     = ""
-}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -128,3 +128,9 @@ variable "managed_node_groups_iam_role_additional_policies" {
   type        = map(string)
   default     = {}
 }
+
+variable "trusted_role_arn" {
+  description = "Additional IAM role passed to KMS Policy"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Update kms encryption policy to pass IAM Role so that we can deploy using cross-account role in higher environments.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

When using cross account IAM role for terraform planning the cluster it fails as the deployer role didn't have access to the kms keys

#### 🛠 How

conditionally injecting via terraform variables

#### 👀 Evidence

![image](https://github.com/Ensono/stacks-terraform/assets/65091252/65e92faf-5514-4528-bc74-7b232023b7db)


#### 🕵️ How to test

After updating the policy we need to run the plan for infrastructure code with cross account IAM role.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
