### PR TITLE
[DRAFT] Feat: Update KMS Policy to conditionally inject additional IAM identities 

### DIFF
--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
+        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
       ]
     }
 

--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -3,6 +3,12 @@ data "aws_caller_identity" "this" {}
 
 data "aws_availability_zones" "available" {}
 
+locals {
+  
+  trusted_key_identities = var.trusted_role_arn == "" ? ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"] : ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"]
+}
+  
+
 ## EKS
 data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
   statement {
@@ -11,10 +17,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
 
     principals {
       type = "AWS"
-
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -44,9 +47,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     principals {
       type = "AWS"
 
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -67,9 +68,7 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     principals {
       type = "AWS"
 
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root","${var.trusted_role_arn}"
-      ]
+      identifiers = local.trusted_key_identities
     }
 
     actions = [

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -79,11 +79,12 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     disk_size = 50
-    placement = {
+    //Only put in temporary so it doesn't force our nodes to be recreated
+    placement = var.eks_node_tenancy == "default" ? {} : {
       tenancy = var.eks_node_tenancy
     }
   }
-
+  
   eks_managed_node_groups = local.eks_managed_node_groups
 
   tags = var.tags

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -79,8 +79,8 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     disk_size = 50
-    //Only put in temporary so it doesn't force our nodes to be recreated
-    placement = var.eks_node_tenancy == "default" ? {} : {
+
+    placement = {
       tenancy = var.eks_node_tenancy
     }
   }

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -45,6 +45,8 @@ locals {
         subnet_ids = [var.vpc_private_subnets[k]]
 
         instance_types = [var.eks_node_size]
+
+        iam_role_additional_policies = var.managed_node_groups_iam_role_additional_policies
       }
     )
   }

--- a/aws/modules/infrastructure_modules/eks/outputs.tf
+++ b/aws/modules/infrastructure_modules/eks/outputs.tf
@@ -3,6 +3,11 @@ output "cluster_id" {
   value       = module.eks.cluster_id
 }
 
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.eks.cluster_arn
+}
+
 output "cluster_endpoint" {
   description = "Endpoint for EKS control plane."
   value       = module.eks.cluster_endpoint

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -130,7 +130,13 @@ variable "managed_node_groups_iam_role_additional_policies" {
 }
 
 variable "trusted_role_arn" {
-  description = "Additional IAM role passed to KMS Policy"
+  description = "IAM role passed to KMS Policy"
+  type        = string
+  default     = ""
+}
+
+variable "trusted_key_identities" {
+  description = "IAM Identities that need to be trusted by the KMS Service"
   type        = string
   default     = ""
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -134,9 +134,3 @@ variable "trusted_role_arn" {
   type        = string
   default     = ""
 }
-
-variable "trusted_key_identities" {
-  description = "IAM Identities that need to be trusted by the KMS Service"
-  type        = string
-  default     = ""
-}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -128,3 +128,9 @@ variable "managed_node_groups_iam_role_additional_policies" {
   type        = map(string)
   default     = {}
 }
+
+variable "trusted_role_arn" {
+  description = "Additional IAM role passed to KMS Policy"
+  type        = string
+  default     = ""
+}

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -95,3 +95,9 @@ variable "eks_node_tenancy" {
     error_message = "Value must be one of 'default', 'dedicated', or 'host'."
   }
 }
+
+variable "managed_node_groups_iam_role_additional_policies" {
+  description = "Additional policies to be added to the Managed Node Group IAM role"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Update kms encryption policy to pass additional IAM Identities so that we can deploy using cross-account role in pre-production/production environments.

#### 🤔 Why

It's recommended to use IAM role to deploy in pre-production/production environments.This improves security posture of the EKS module.

#### 🛠 How

By conditional injecting IAM Identities when required by the root module.


#### 👀 Evidence

Issue
<img width="2547" alt="image" src="https://github.com/Ensono/stacks-terraform/assets/65091252/f0ac8859-1668-476e-9746-1b6913d69ae3">


#### 🕵️ How to test

After deploying the changes we need to re-run the plan form the root terraform module to verify that above issue got resolved.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
