### PR TITLE
feat: Inject additional AWS Identities

### DIFF
--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -3,6 +3,11 @@ data "aws_caller_identity" "this" {}
 
 data "aws_availability_zones" "available" {}
 
+locals {
+
+  trusted_key_identities = var.trusted_role_arn == "" ? ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"] : ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root", "${var.trusted_role_arn}"]
+}
+
 ## EKS
 data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
   statement {
@@ -10,11 +15,8 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     effect = "Allow"
 
     principals {
-      type = "AWS"
-
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
-      ]
+      type        = "AWS"
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -42,11 +44,8 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     effect = "Allow"
 
     principals {
-      type = "AWS"
-
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
-      ]
+      type        = "AWS"
+      identifiers = local.trusted_key_identities
     }
 
     actions = [
@@ -65,11 +64,8 @@ data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {
     effect = "Allow"
 
     principals {
-      type = "AWS"
-
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root",
-      ]
+      type        = "AWS"
+      identifiers = local.trusted_key_identities
     }
 
     actions = [

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -121,3 +121,8 @@ variable "cluster_security_group_additional_rules" {
     }
   }
 }
+variable "trusted_role_arn" {
+  description = "IAM role passed to KMS Policy"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Update kms encryption policy to pass additional IAM Identities so that we can deploy using cross-account role in pre-production/production environments.

#### 🤔 Why

It's recommended to use IAM role to deploy in pre-production/production environments.This improves security posture of the EKS module.

#### 🛠 How

By conditional injecting IAM Identities when required by the root module.


#### 👀 Evidence

Issue
<img width="2547" alt="image" src="https://github.com/Ensono/stacks-terraform/assets/65091252/f0ac8859-1668-476e-9746-1b6913d69ae3">


#### 🕵️ How to test

After deploying the changes we need to re-run the plan form the root terraform module to verify that above issue got resolved.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?

