### PR TITLE
Exposing kubelet garbage collection threshold via variables

### DIFF
--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -32,6 +32,10 @@ locals {
   "net.ipv4.conf.default.secure_redirects" = "0"
   "net.ipv4.conf.all.log_martians" = "1"
   "net.ipv4.conf.default.log_martians" = "1"
+
+  [settings.kubernetes]
+  image-gc-high-threshold-percent = "${var.image_gc_high_threshold_percent}"
+  image-gc-low-threshold-percent = "${var.image_gc_low_threshold_percent}"
   %{endif}
   EOT
 

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -121,8 +121,21 @@ variable "cluster_security_group_additional_rules" {
     }
   }
 }
+
 variable "trusted_role_arn" {
   description = "IAM role passed to KMS Policy"
   type        = string
   default     = ""
+}
+
+variable "image_gc_high_threshold_percent" {
+  description = "The percent of disk usage that initiates image garbage collection by kubelet. This value must be greater than the low threshold value"
+  type = number
+  default = 85
+}
+
+variable "image_gc_low_threshold_percent" {
+  description = "The kubelet deletes images until disk usage reaches this valuee. This value must be less than the high threshold value"
+  type = number
+  default = 80
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -135,7 +135,7 @@ variable "image_gc_high_threshold_percent" {
 }
 
 variable "image_gc_low_threshold_percent" {
-  description = "The kubelet deletes images until disk usage reaches this valuee. This value must be less than the high threshold value"
+  description = "The kubelet deletes images until disk usage reaches this value. This value must be less than the high threshold value"
   type        = number
   default     = 80
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -130,12 +130,12 @@ variable "trusted_role_arn" {
 
 variable "image_gc_high_threshold_percent" {
   description = "The percent of disk usage that initiates image garbage collection by kubelet. This value must be greater than the low threshold value"
-  type = number
-  default = 85
+  type        = number
+  default     = 85
 }
 
 variable "image_gc_low_threshold_percent" {
   description = "The kubelet deletes images until disk usage reaches this valuee. This value must be less than the high threshold value"
-  type = number
-  default = 80
+  type        = number
+  default     = 80
 }


### PR DESCRIPTION
#### 📲 What

Exposing the kubelet garbage collection threshold settings via variables

#### 🤔 Why

We keep getting Disk Pressure issues on our EKS node due as the pod images take a lot of space. With the default setting kubelet does the garbage collection when disk usage reaches 85% which might be quite high. So we want to reduce this threshold limit.

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

<img width="1333" alt="Screenshot 2024-06-06 at 09 59 28" src="https://github.com/Ensono/stacks-terraform/assets/78567578/f933d039-fdb7-4052-9aad-3f05b1475281">

#### 🕵️ How to test

We might get the kubelet logs from nodes but not sure if we will be able to confirm at what disk percent it triggered garbage collection. We are just hoping after setting the threshold to a lower value to run garbage collection early.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
