### PR TITLE
FIX: Update custom KMS Policy to add IAM Identities

### DIFF
--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -54,7 +54,7 @@ module "eks" {
 
 
   create_kms_key         = var.create_kms_key
-  kms_key_administrators = var.kms_key_administrators
+  kms_key_administrators = var.trusted_role_arn == "" ? [] : ["${data.aws_caller_identity.this.arn}", "${var.trusted_role_arn}"]
 
   cluster_encryption_config = {
     resources        = ["secrets"]

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -51,9 +51,11 @@ module "eks" {
   }
 
   cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-  
-  create_kms_key = var.create_kms_key
-  
+
+
+  create_kms_key         = var.create_kms_key
+  kms_key_administrators = var.kms_key_administrators
+
   cluster_encryption_config = {
     resources        = ["secrets"]
     provider_key_arn = module.eks_kms_key.arn

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -51,7 +51,9 @@ module "eks" {
   }
 
   cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-
+  
+  create_kms_key = var.create_kms_key
+  
   cluster_encryption_config = {
     resources        = ["secrets"]
     provider_key_arn = module.eks_kms_key.arn

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -141,6 +141,12 @@ variable "image_gc_low_threshold_percent" {
 }
 
 variable "create_kms_key" {
-  description = "Controls if a KMS key for cluster encryption should be created which is true by default, making it false will enable to pass custom kms key and policy"
+  description = "[ Warn: breaking-change ] Making this value false will allow passing a custom KMS key via the provider_key_arn configuration"
   type        = bool
+  default     = true
+}
+
+variable "kms_key_administrators" {
+  type        = list(string)
+  description = "List of IAM identities for the keys which is used to encrypt data within the Cluster"
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -147,12 +147,6 @@ variable "create_kms_key" {
   default     = true
 }
 
-variable "kms_key_administrators" {
-  type        = list(string)
-  description = "List of IAM identities for the keys which is used to encrypt data within the Cluster"
-  default     = []
-}
-
 variable "node_security_group_additional_rules" {
   description = "List of additional security group rules to add to the node security group created. Set source_cluster_security_group = true inside rules to set the cluster_security_group as source"
   type        = any

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -149,4 +149,5 @@ variable "create_kms_key" {
 variable "kms_key_administrators" {
   type        = list(string)
   description = "List of IAM identities for the keys which is used to encrypt data within the Cluster"
+  default     = []
 }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -139,3 +139,8 @@ variable "image_gc_low_threshold_percent" {
   type        = number
   default     = 80
 }
+
+variable "create_kms_key" {
+  description = "Controls if a KMS key for cluster encryption should be created which is true by default, making it false will enable to pass custom kms key and policy"
+  type        = bool
+}


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

To conditionally inject IAM Identities to the KMS Key that used for secret encryption within the cluster. If no IAM role is passed the KMS Policy has only access to the identity that is used to deploy the infrastructure.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

This gives flexibility to use IAM User in lower environment and IAM Role in higher environment to access the cluster encryption key and infrastructure deployment.

There are few gotchas like currently apart from the identity used to deploy the infra nobody has access even to view the KMS key making it difficult to manage, this is fixed in later version of the terraform module (V 20.0.0 )

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2816

#### 🛠 How

Using conditional statement.

#### 👀 Evidence
<img width="751" alt="image" src="https://github.com/Ensono/stacks-terraform/assets/65091252/620d88fa-151b-4ca6-9394-c99a81af1a78">

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.

#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
