### PR TITLE
fix: bumps the EKS module version for Kubernetes >=1.30

### DIFF
--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -45,10 +45,6 @@ module "eks" {
 
   authentication_mode = "CONFIG_MAP"
 
-  # Don't manage this through the module, it's incredibly hard to get working right.
-  create_aws_auth_configmap = false
-  manage_aws_auth_configmap = false
-
   eks_managed_node_group_defaults = {
     disk_size = 50
 

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -17,7 +17,7 @@ module "eks_kms_key" {
 #############
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.20"
+  version = "~> 20.17`"
 
   vpc_id                          = var.vpc_id
   subnet_ids                      = var.vpc_private_subnets

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -42,6 +42,13 @@ module "eks" {
     provider_key_arn = module.eks_kms_key.arn
   }
 
+  # OIDC Identity provider
+  cluster_identity_providers = {
+    sts = {
+      client_id = "sts.amazonaws.com"
+    }
+  }
+
   authentication_mode                      = "API_AND_CONFIG_MAP"
   enable_cluster_creator_admin_permissions = var.cluster_creator_admin_permissions
 

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -43,11 +43,11 @@ module "eks" {
   }
 
   # OIDC Identity provider
-  cluster_identity_providers = {
-    sts = {
-      client_id = "sts.amazonaws.com"
-    }
-  }
+  # cluster_identity_providers = {
+  #   sts = {
+  #     client_id = "sts.amazonaws.com"
+  #   }
+  # }
 
   authentication_mode                      = "API_AND_CONFIG_MAP"
   enable_cluster_creator_admin_permissions = var.cluster_creator_admin_permissions

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -17,7 +17,7 @@ module "eks_kms_key" {
 #############
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.17`"
+  version = "~> 20.17"
 
   vpc_id                          = var.vpc_id
   subnet_ids                      = var.vpc_private_subnets

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -43,7 +43,8 @@ module "eks" {
     provider_key_arn = module.eks_kms_key.arn
   }
 
-  authentication_mode = "CONFIG_MAP"
+  authentication_mode                      = "CONFIG_MAP"
+  enable_cluster_creator_admin_permissions = true
 
   eks_managed_node_group_defaults = {
     disk_size = 50

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -43,8 +43,8 @@ module "eks" {
     provider_key_arn = module.eks_kms_key.arn
   }
 
-  authentication_mode                      = "CONFIG_MAP"
-  enable_cluster_creator_admin_permissions = true
+  authentication_mode                      = "API_AND_CONFIG_MAP"
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   eks_managed_node_group_defaults = {
     disk_size = 50

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -43,12 +43,7 @@ module "eks" {
     provider_key_arn = module.eks_kms_key.arn
   }
 
-  # OIDC Identity provider
-  cluster_identity_providers = {
-    sts = {
-      client_id = "sts.amazonaws.com"
-    }
-  }
+  authentication_mode = "CONFIG_MAP"
 
   # Don't manage this through the module, it's incredibly hard to get working right.
   create_aws_auth_configmap = false

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -32,7 +32,7 @@ module "eks" {
   node_security_group_additional_rules         = var.node_security_group_additional_rules
   node_security_group_enable_recommended_rules = var.node_security_group_enable_recommended_rules
 
-  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  cluster_enabled_log_types = var.cluster_enabled_log_types
 
   create_kms_key         = var.create_kms_key
   kms_key_administrators = var.trusted_role_arn == "" ? [] : ["${data.aws_caller_identity.this.arn}", "${var.trusted_role_arn}"]

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -34,7 +34,6 @@ module "eks" {
 
   cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
-
   create_kms_key         = var.create_kms_key
   kms_key_administrators = var.trusted_role_arn == "" ? [] : ["${data.aws_caller_identity.this.arn}", "${var.trusted_role_arn}"]
 
@@ -44,7 +43,7 @@ module "eks" {
   }
 
   authentication_mode                      = "API_AND_CONFIG_MAP"
-  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
+  enable_cluster_creator_admin_permissions = var.cluster_creator_admin_permissions
 
   eks_managed_node_group_defaults = {
     disk_size = 50

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -42,13 +42,6 @@ module "eks" {
     provider_key_arn = module.eks_kms_key.arn
   }
 
-  # OIDC Identity provider
-  # cluster_identity_providers = {
-  #   sts = {
-  #     client_id = "sts.amazonaws.com"
-  #   }
-  # }
-
   authentication_mode                      = "API_AND_CONFIG_MAP"
   enable_cluster_creator_admin_permissions = var.cluster_creator_admin_permissions
 

--- a/aws/modules/infrastructure_modules/eks/outputs.tf
+++ b/aws/modules/infrastructure_modules/eks/outputs.tf
@@ -18,11 +18,6 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
-output "config_map_aws_auth" {
-  description = "A kubernetes configuration to authenticate to this EKS cluster."
-  value       = module.eks.aws_auth_configmap_yaml
-}
-
 output "region" {
   description = "AWS region"
   value       = var.region

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -44,6 +44,13 @@ variable "cluster_single_az" {
   description = "Spin up the cluster in a single AZ"
 }
 
+variable "cluster_creator_admin_permissions" {
+  type        = bool
+  description = "Adds the Terraform User that creates the cluster as an administrator"
+
+  default = true
+}
+
 variable "eks_minimum_nodes" {
   type        = string
   description = "The minimum number of nodes in the cluster, per AZ if 'cluster_single_az' is false"

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -51,6 +51,13 @@ variable "cluster_creator_admin_permissions" {
   default = true
 }
 
+variable "cluster_enabled_log_types" {
+  type        = list(string)
+  description = "A list of the log types to log, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html"
+
+  default = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+}
+
 variable "eks_minimum_nodes" {
   type        = string
   description = "The minimum number of nodes in the cluster, per AZ if 'cluster_single_az' is false"

--- a/build/azdo/azuredevops-runner.yml
+++ b/build/azdo/azuredevops-runner.yml
@@ -1,6 +1,6 @@
 
 # Set the build name which will define the Build Number
-name: 3.0$(Rev:.r)
+name: 4.0$(Rev:.r)
 
 pr:
   - master


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Upgrades the module to 20.x which fixes this here: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3055

```
infra:apply: │ Error: associating EKS Identity Provider Config (ensono-stacks-nonprod-ew2-eks:sts): operation error EKS: AssociateIdentityProviderConfig, https response error StatusCode: 400, RequestID: <redacted>, InvalidParameterException: Incorrect Identity Provider URL configuration. The Identity Provider URL cannot be same as OpenID Connect (OIDC) issuer URL
infra:apply: │
infra:apply: │   with module.amido_stacks_infra.module.eks.aws_eks_identity_provider_config.this["sts"],
infra:apply: │   on .terraform/modules/amido_stacks_infra.eks/main.tf line 453, in resource "aws_eks_identity_provider_config" "this":
infra:apply: │  453: resource "aws_eks_identity_provider_config" "this" {
infra:apply: │
infra:apply: ╵
```

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

Kubernetes 1.30 seems to not like the Issuer URL being the same as the OIDC URL.

#### 🛠 How

Upgrades module

#### 👀 Evidence

#### 🕵️ How to test

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
