### PR TITLE
feat: Adds AKS Cluster Sku Tier for Control Plane

### DIFF
--- a/azurerm/modules/azurerm-aks/aks.tf
+++ b/azurerm/modules/azurerm-aks/aks.tf
@@ -6,6 +6,7 @@ resource "azurerm_container_registry" "registry" {
   location            = var.resource_group_location
   admin_enabled       = var.registry_admin_enabled
   sku                 = var.registry_sku
+
   lifecycle {
     ignore_changes = [
       tags,
@@ -27,7 +28,9 @@ resource "azurerm_kubernetes_cluster" "default" {
   resource_group_name     = azurerm_resource_group.default.name
   dns_prefix              = var.dns_prefix
   kubernetes_version      = var.cluster_version
+  sku_tier                = var.cluster_sku_tier
   private_cluster_enabled = var.private_cluster_enabled
+
   linux_profile {
     admin_username = var.admin_username
     ssh_key {

--- a/azurerm/modules/azurerm-aks/variables.tf
+++ b/azurerm/modules/azurerm-aks/variables.tf
@@ -193,6 +193,18 @@ variable "cluster_version" {
   default     = "1.24.6"
 }
 
+variable "cluster_sku_tier" {
+  description = "The Control Plane SKU Tier"
+  type        = string
+
+  validation {
+    condition     = contains(["Free", "Standard", "Premium"], var.cluster_sky_tier])
+    error_message = "Must be one of Free, Standard, or Premium."
+  }
+
+  default = "Free"
+}
+
 variable "cluster_name" {
   description = "Name for the cluster"
   default     = "akscluster"

--- a/azurerm/modules/azurerm-aks/variables.tf
+++ b/azurerm/modules/azurerm-aks/variables.tf
@@ -198,7 +198,7 @@ variable "cluster_sku_tier" {
   type        = string
 
   validation {
-    condition     = contains(["Free", "Standard", "Premium"], var.cluster_sky_tier)
+    condition     = contains(["Free", "Standard", "Premium"], var.cluster_sku_tier)
     error_message = "Must be one of Free, Standard, or Premium."
   }
 

--- a/azurerm/modules/azurerm-aks/variables.tf
+++ b/azurerm/modules/azurerm-aks/variables.tf
@@ -198,7 +198,7 @@ variable "cluster_sku_tier" {
   type        = string
 
   validation {
-    condition     = contains(["Free", "Standard", "Premium"], var.cluster_sky_tier])
+    condition     = contains(["Free", "Standard", "Premium"], var.cluster_sky_tier)
     error_message = "Must be one of Free, Standard, or Premium."
   }
 


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Adds Cluster SKU Tier for the AKS Control Plane

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

Currently it's automatically set to Free which isn't good for Production Environments, also Azure's capacity for Free clusters is much lower and this can lead to errors.

#### 🛠 How

#### 👀 Evidence

#### 🕵️ How to test

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
