### PR TITLE
feat: Expose the Additional IAM roles for the EKS

### DIFF
--- a/aws/modules/infrastructure_modules/eks/data.tf
+++ b/aws/modules/infrastructure_modules/eks/data.tf
@@ -1,12 +1,6 @@
-# Current account ID
 data "aws_caller_identity" "this" {}
 
 data "aws_availability_zones" "available" {}
-
-locals {
-
-  trusted_key_identities = var.trusted_role_arn == "" ? ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"] : ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root", "${var.trusted_role_arn}"]
-}
 
 ## EKS
 data "aws_iam_policy_document" "eks_secret_encryption_kms_key_policy" {

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -17,7 +17,7 @@ module "eks_kms_key" {
 #############
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.17"
+  version = "~> 20.19"
 
   vpc_id                          = var.vpc_id
   subnet_ids                      = var.vpc_private_subnets
@@ -31,6 +31,8 @@ module "eks" {
 
   node_security_group_additional_rules         = var.node_security_group_additional_rules
   node_security_group_enable_recommended_rules = var.node_security_group_enable_recommended_rules
+
+  iam_role_additional_policies = var.cluster_iam_role_additional_policies
 
   cluster_enabled_log_types = var.cluster_enabled_log_types
 

--- a/aws/modules/infrastructure_modules/eks/examples/main.tf
+++ b/aws/modules/infrastructure_modules/eks/examples/main.tf
@@ -1,3 +1,7 @@
+data "aws_iam_policy" "cloudwatch_agent_server_policy" {
+  name = "CloudWatchAgentServerPolicy"
+}
+
 module "vpc" {
   source = "../../vpc"
 
@@ -19,13 +23,16 @@ module "eks" {
   region = "eu-west-1"
 
   # EKS Cluster Configuration
-  cluster_name                    = "example-cluster"
-  cluster_version                 = "1.27"
-  eks_desired_nodes               = 1
-  eks_node_size                   = "t3.small"
-  cluster_endpoint_public_access  = true
-  cluster_endpoint_private_access = true
-  cluster_single_az               = false
+  cluster_name                         = "example-cluster"
+  cluster_version                      = "1.27"
+  eks_desired_nodes                    = 1
+  eks_node_size                        = "t3.small"
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_private_access      = true
+  cluster_single_az                    = false
+  cluster_iam_role_additional_policies = {
+    cloudwatch_agent_server_policy = data.aws_iam_policy.cloudwatch_agent_server_policy.arn
+  }
 
   vpc_id              = module.vpc.id
   vpc_private_subnets = module.vpc.private_subnet_ids

--- a/aws/modules/infrastructure_modules/eks/examples/main.tf
+++ b/aws/modules/infrastructure_modules/eks/examples/main.tf
@@ -23,13 +23,14 @@ module "eks" {
   region = "eu-west-1"
 
   # EKS Cluster Configuration
-  cluster_name                         = "example-cluster"
-  cluster_version                      = "1.27"
-  eks_desired_nodes                    = 1
-  eks_node_size                        = "t3.small"
-  cluster_endpoint_public_access       = true
-  cluster_endpoint_private_access      = true
-  cluster_single_az                    = false
+  cluster_name                    = "example-cluster"
+  cluster_version                 = "1.27"
+  eks_desired_nodes               = 1
+  eks_node_size                   = "t3.small"
+  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = true
+  cluster_single_az               = false
+
   cluster_iam_role_additional_policies = {
     cloudwatch_agent_server_policy = data.aws_iam_policy.cloudwatch_agent_server_policy.arn
   }

--- a/aws/modules/infrastructure_modules/eks/locals.tf
+++ b/aws/modules/infrastructure_modules/eks/locals.tf
@@ -84,6 +84,8 @@ locals {
     })
   )
 
+  trusted_key_identities = var.trusted_role_arn == "" ? ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"] : ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root", "${var.trusted_role_arn}"]
+
   logging_bucket_kms_key_name                    = "alias/cmk-${lower(var.cluster_name)}-logging-bucket"
   logging_bucket_kms_key_description             = "Secret Encryption Key for the Flow Log Bucket"
   logging_bucket_kms_key_deletion_window_in_days = "7"

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -58,6 +58,13 @@ variable "cluster_enabled_log_types" {
   default = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 }
 
+variable "cluster_iam_role_additional_policies" {
+  type        = map(string)
+  description = "Additional policies to be added to the IAM role for the EKS Cluster"
+
+  default = {}
+}
+
 variable "eks_minimum_nodes" {
   type        = string
   description = "The minimum number of nodes in the cluster, per AZ if 'cluster_single_az' is false"


### PR DESCRIPTION
#### 📲 What

Expose the Additional IAM roles for the EKS.

#### 🤔 Why

For the CloudWatch add-on to work the cluster needs an additional role, so expose the parameter from the underlying module to allow additional policies to be added.

#### 🛠 How

#### 👀 Evidence

![image](https://github.com/user-attachments/assets/4e575523-a4e7-46fe-a95f-b3f80f8afe17)

#### 🕵️ How to test

Use example to spin up a cluster

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
