### PR TITLE
fix: create sqs subscription if queue enabled

### DIFF
--- a/aws/modules/infrastructure_modules/stacks_app/app.tf
+++ b/aws/modules/infrastructure_modules/stacks_app/app.tf
@@ -36,6 +36,6 @@ module "topic" {
   name   = var.queue_name
   tags   = var.tags
 
-  create_sqs_subscription    = true
+  create_sqs_subscription    = var.enable_queue
   subscription_sqs_queue_arn = module.queue.sqs_queue_arn
 }


### PR DESCRIPTION
#### 📲 What

Update stacks-app to create sqs subscription if the enable_queue flag is set. 

#### 🤔 Why

Using the module currently fails when enable_queue is false as it tries to create a subscription for a topic that o

#### 🛠 How

Replace hard-coded value with variable

#### 👀 Evidence

https://github.com/Ensono/stacks-terraform/blob/master/aws/modules/resource_modules/application_integration/sns/main.tf#L13

#### 🕵️ How to test


#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
