### PR TITLE
Add app gateway SKU variables

### DIFF
--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -101,12 +101,13 @@ resource "azurerm_application_gateway" "network" {
 
   probe {
     name                = "k8s-probe"
-    host                = "127.0.0.1"
+    host                = var.pick_host_name_from_backend_http_settings ? null : "127.0.0.1"
     protocol            = "Http"
     interval            = 15
     unhealthy_threshold = 4
     timeout             = 15
     path                = "/healthz"
+    pick_host_name_from_backend_http_settings = var.pick_host_name_from_backend_http_settings 
     match {
       status_code = ["200"]
     }
@@ -119,6 +120,7 @@ resource "azurerm_application_gateway" "network" {
     protocol              = "Http"
     request_timeout       = 10
     probe_name            = "k8s-probe"
+    host_name             = var.host_name
   }
 
   request_routing_rule {

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -121,6 +121,7 @@ resource "azurerm_application_gateway" "network" {
   }
 
   request_routing_rule {
+    priority                   = 1
     name                       = local.request_routing_rule_name
     rule_type                  = "Basic"
     http_listener_name         = local.listener_name
@@ -129,6 +130,7 @@ resource "azurerm_application_gateway" "network" {
   }
 
   request_routing_rule {
+    priority                   = 2
     name                       = local.request_routing_rule_name_ssl
     rule_type                  = "Basic"
     http_listener_name         = local.listener_name_ssl

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -19,6 +19,7 @@ resource "azurerm_public_ip" "app_gateway" {
   resource_group_name = var.resource_group_name
   location            = var.resource_group_location
   allocation_method   = "Dynamic"
+  sku                 = "Standard"
   lifecycle {
     ignore_changes = [
       tags,

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -47,8 +47,8 @@ resource "azurerm_application_gateway" "network" {
   location = var.resource_group_location
 
   sku {
-    name     = "Standard_Small"
-    tier     = "Standard"
+    name     = var.app_gateway_sku
+    tier     = var.app_gateway_tier
     capacity = 2
   }
 

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -100,14 +100,14 @@ resource "azurerm_application_gateway" "network" {
   }
 
   probe {
-    name                = "k8s-probe"
-    host                = var.pick_host_name_from_backend_http_settings ? null : "127.0.0.1"
-    protocol            = "Http"
-    interval            = 15
-    unhealthy_threshold = 4
-    timeout             = 15
-    path                = "/healthz"
-    pick_host_name_from_backend_http_settings = var.pick_host_name_from_backend_http_settings 
+    name                                      = "k8s-probe"
+    host                                      = var.pick_host_name_from_backend_http_settings ? null : "127.0.0.1"
+    protocol                                  = "Http"
+    interval                                  = 15
+    unhealthy_threshold                       = 4
+    timeout                                   = 15
+    path                                      = "/healthz"
+    pick_host_name_from_backend_http_settings = var.pick_host_name_from_backend_http_settings
     match {
       status_code = ["200"]
     }

--- a/azurerm/modules/azurerm-app-gateway/app_gateway.tf
+++ b/azurerm/modules/azurerm-app-gateway/app_gateway.tf
@@ -18,7 +18,7 @@ resource "azurerm_public_ip" "app_gateway" {
   name                = var.resource_namer
   resource_group_name = var.resource_group_name
   location            = var.resource_group_location
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   sku                 = "Standard"
   lifecycle {
     ignore_changes = [

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -185,3 +185,15 @@ variable "acme_email" {
   type        = string
   description = "Email for Acme registration, must be a valid email"
 }
+
+variable "pick_host_name_from_backend_http_settings" {
+  type        = bool
+  default     = false
+  description = "Whether the host header should be picked from the backend HTTP settings. Defaults to false."
+}
+
+variable "host_name" {
+  type        = string
+  default     = null
+  description = "Host header to be sent to the backend servers. Cannot be set if pick_host_name_from_backend_address is set to true"
+}

--- a/azurerm/modules/azurerm-app-gateway/vars.tf
+++ b/azurerm/modules/azurerm-app-gateway/vars.tf
@@ -155,6 +155,18 @@ variable "create_valid_cert" {
   description = "States if a certificate should be requested from LetsEncrypt (true) or a self-signed certificate should be generated (false)"
 }
 
+variable "app_gateway_sku" {
+  type        = string
+  default     = "Standard_v2"
+  description = "he Name of the SKU to use for this Application Gateway. Possible values are Standard_Small, Standard_Medium, Standard_Large, Standard_v2, WAF_Medium, WAF_Large, and WAF_v2"
+}
+
+variable "app_gateway_tier" {
+  type        = string
+  default     = "Standard_v2"
+  description = "The Tier of the SKU to use for this Application Gateway. Possible values are Standard_v2, WAF_v2"
+}
+
 ###########################
 # MISC SETTINGS
 ##########################


### PR DESCRIPTION
#### 📲 What

Updated AppGateway to SKU StandardV2. This meant a priority needed to be added to rules and the Public IP address needed to be set as static with a standard SKU, https://thomasthornton.cloud/2023/12/12/resolving-terraform-error-applicationgatewayinvalidpublicipsku-application-gateway-sku-mismatch-with-public-ip/.

Added pick_host_name_from_backend_http_settings  and host_name variables because we want to set these when deploying Azure Container Apps

#### 🤔 Why

Standard SKU is not supported


