### PR TITLE
Add block device mapping

### DIFF
--- a/aws/modules/infrastructure_modules/eks/README.md
+++ b/aws/modules/infrastructure_modules/eks/README.md
@@ -86,6 +86,7 @@ and: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/920
 | <a name="input_trusted_role_arn"></a> [trusted\_role\_arn](#input\_trusted\_role\_arn) | IAM role passed to KMS Policy | `string` | `""` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to use for the Cluster and resources | `string` | n/a | yes |
 | <a name="input_vpc_private_subnets"></a> [vpc\_private\_subnets](#input\_vpc\_private\_subnets) | The VPC Private Subnets to place EKS nodes into | `list(string)` | n/a | yes |
+| <a name="block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instances. This is useful if you want to increase the volume where the container image layers are stored. Default is 20gb | `map(any)` | n/a | no |
 
 ## Outputs
 

--- a/aws/modules/infrastructure_modules/eks/eks-cluster.tf
+++ b/aws/modules/infrastructure_modules/eks/eks-cluster.tf
@@ -48,8 +48,8 @@ module "eks" {
   enable_cluster_creator_admin_permissions = var.cluster_creator_admin_permissions
 
   eks_managed_node_group_defaults = {
-    disk_size = 50
-
+    disk_size             = 50
+    block_device_mappings = var.block_device_mappings
     placement = {
       tenancy = var.eks_node_tenancy
     }

--- a/aws/modules/infrastructure_modules/eks/variables.tf
+++ b/aws/modules/infrastructure_modules/eks/variables.tf
@@ -209,3 +209,9 @@ variable "node_security_group_enable_recommended_rules" {
   type        = bool
   default     = true
 }
+
+variable "block_device_mappings" {
+  description = "Specify volumes to attach to the instances. This is useful if you want to increase the volume where the container image layers are stored. Default is 20gb"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION

#### 📲 What

Add block device mapping variable to be passed to the eks module

#### 🤔 Why

So can override the volumes to attach to the instances. By default the attached OS and container image is unencrypted and set to 20gb and 2gb which you can now override.

#### 🛠 How

Example below is setting the OS and Container image volumes to be encrypted and use gp3.
```

    block_device_mappings = {
     #OS
      xvda = {
        device_name = "/dev/xvda"
        ebs         = {
          volume_size           = 2
          volume_type           = "gp3"
          iops                  = 3000
          throughput            = 150
          encrypted             = true
          delete_on_termination = true
        }
      }
     #Container Image Layers
      xvdb = {
        device_name = "/dev/xvdb"
        ebs         = {
          volume_size           = 20
          volume_type           = "gp3"
          iops                  = 3000
          throughput            = 150
          encrypted             = true
          delete_on_termination = true
        }
      }
    }
  }
```

#### 👀 Evidence

