### PR TITLE
fix: fixes lambda subnet naming

### DIFF
--- a/aws/modules/infrastructure_modules/vpc/vpc.tf
+++ b/aws/modules/infrastructure_modules/vpc/vpc.tf
@@ -117,7 +117,7 @@ resource "aws_subnet" "lambda" {
   tags = merge(
     var.tags,
     {
-      Name                              = "${var.vpc_name}-public-${local.sorted_azs[count.index]}"
+      Name                              = "${var.vpc_name}-lambda-${local.sorted_azs[count.index]}"
       "kubernetes.io/role/internal-elb" = "0"
       "kubernetes.io/role/elb"          = "0"
       isPrivate                         = "true"


### PR DESCRIPTION
 * Fixes lambda subnet naming, incorrectly 'public' instead of 'lambda'.